### PR TITLE
Use a default model if no versions are selected

### DIFF
--- a/components/ui/Canvas.vue
+++ b/components/ui/Canvas.vue
@@ -23,7 +23,7 @@
       @mousedown.stop="startSelection"
       :data-id="output.id"
     )
-      u-tooltip(:text="output.metadata.name")
+      u-tooltip(:text="output.metadata.name || 'Flux'")
         template(v-if="output.status === 'succeeded'")
           img(
             v-if="output.output && output.output[0]"

--- a/components/ui/form/Create.vue
+++ b/components/ui/form/Create.vue
@@ -12,7 +12,6 @@
       option-attribute="name"
       value-attribute="version"
       multiple
-      required
     )
   u-form-group(
     v-if="trigger_words.length > 0"
@@ -57,7 +56,6 @@
     )
   //- Number of outputs (conditional)
   u-form-group(
-    v-if="versions.length <= 1"
     label="Number of outputs"
     name="num_outputs"
   )
@@ -174,7 +172,7 @@
   u-button(
     v-if="replicate_api_token"
     @click="submit"
-    :disabled="loading || !replicate_api_token || versions.length <= 0"
+    :disabled="loading || !replicate_api_token"
     :loading="loading"
     size="xl"
     block

--- a/server/api/prediction.post.js
+++ b/server/api/prediction.post.js
@@ -1,18 +1,33 @@
 export default defineEventHandler(async (event) => {
   try {
     const { replicate_api_token, version, input } = await readBody(event)
+    let result;
 
-    const result = await fetch('https://api.replicate.com/v1/predictions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${replicate_api_token}`,
-        'User-Agent': 'ReFlux/1.0'
-      },
-      body: JSON.stringify({
-        version,
-        input
+    if (!version) {
+      result = await fetch('https://api.replicate.com/v1/models/black-forest-labs/flux-schnell/predictions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${replicate_api_token}`,
+          'User-Agent': 'ReFlux/1.0',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          input
+        })
       })
-    })
+    } else {
+      result = await fetch('https://api.replicate.com/v1/predictions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${replicate_api_token}`,
+          'User-Agent': 'ReFlux/1.0'
+        },
+        body: JSON.stringify({
+          version,
+          input
+        })
+      })
+    }
 
     const prediction = await result.json()
 


### PR DESCRIPTION
## Use a default model if no versions are selected

### Changes
- Remove form requirements
- Add default endpoint if no version provided

### Reason
It would be more useful if a user can just jump in an start prompting, versions are not very descriptive and not always necessary. 

### Testing
- [ ] None

### Additional Notes
The default endpoint is hard coded as 'flux-schnell/predictions', should this use flux-dev instead? Should this be a const instead?
Also, Flux is hardcoded as the version name after getting a completion because without a version it returns null, should that be the model name instead? 

Open to feedback, thank you! 
